### PR TITLE
restore origin and spacing info of original label after label mapping

### DIFF
--- a/nnunet_ext/experiment_planning/dataset_label_mapping.py
+++ b/nnunet_ext/experiment_planning/dataset_label_mapping.py
@@ -108,10 +108,13 @@ def _perform_transformation_on_mask_using_mapping(mask, mapping, join_labels):
     img_array = np.absolute(img_array)
 
     # -- Convert the transformed numpy array back to a SimpleITK image and save the new mask by overwriting the old one -- #
-    mask = sitk.GetImageFromArray(img_array)
+    new_mask = sitk.GetImageFromArray(img_array)
+
+    # -- Preserve the metadata (origin, spacing, and direction) from the original mask -- #
+    new_mask.CopyInformation(mask)
     
     # -- Return the new mask image -- #
-    return mask
+    return new_mask
             
 
 def main(use_parser=True, **kwargs):


### PR DESCRIPTION
nnUNet alerted me during dataset preprocessing that the geometric information between labels and training images is different after label mapping. I changed  the code to ensure that the geometric metadata is restored after label mapping, which resolved this issue. I tested it out with the DecathProst and ISBI datasets, which have more than two labels and need label mapping to be compatible with the other prostata datasets.